### PR TITLE
Simple tests for Turbine

### DIFF
--- a/common/src/commonMain/kotlin/karat/concrete/Formula.kt
+++ b/common/src/commonMain/kotlin/karat/concrete/Formula.kt
@@ -96,6 +96,10 @@ public fun <A, R> predicate(
   test: (A) -> R
 ): Predicate<A, R> = NonSuspendedPredicate(test)
 
+public fun <A, R> remember(
+  block: (A) -> Formula<A, R>
+): Remember<A, R> = Remember(block)
+
 public data class Not<in A, out R>(
   val formula: Atomic<A, R>
 ): Formula<A, R>

--- a/kotlin/kotest/src/commonMain/kotlin/karat/kotest/ArbModel.kt
+++ b/kotlin/kotest/src/commonMain/kotlin/karat/kotest/ArbModel.kt
@@ -74,9 +74,9 @@ public suspend fun <AbstractState, ConcreteState, Action, Response> checkAgainst
   initial: ConcreteState,
   step: suspend (Action, ConcreteState) -> Step<ConcreteState, Response>?,
   range: IntRange = 1 .. 100,
-  formula: ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Unit>.() -> KotlinTestFormula<Info<Action, ConcreteState, Response>>
+  formula: ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Any?>.() -> KotlinTestFormula<Info<Action, ConcreteState, Response>>
 ): Unit =
-  ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Unit>()
+  ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Any?>()
     .run(formula)
     .let { checkAgainst(model, initial, step, range, it) }
 
@@ -87,7 +87,7 @@ public suspend fun <AbstractState, ConcreteState, Action, Response> checkTraceAg
   range: IntRange = 1 .. 100,
   formula: suspend TraceFormulaBuilder<
       Info<Action, ConcreteState, Response>,
-      suspend (Info<Action, ConcreteState, Response>) -> Unit,
+      suspend (Info<Action, ConcreteState, Response>) -> Any?,
       KotlinTestFormula<Info<Action, ConcreteState, Response>>,
       KotlinTestAtomic<Info<Action, ConcreteState, Response>>
     >.() -> Unit

--- a/kotlin/test-common/src/commonMain/kotlin/karat/kotlin/test/Errors.kt
+++ b/kotlin/test-common/src/commonMain/kotlin/karat/kotlin/test/Errors.kt
@@ -3,7 +3,10 @@ package karat.kotlin.test
 public open class StateAssertionError(
   public val state: Any?,
   public val problems: List<AssertionError>
-): AssertionError()
+): AssertionError() {
+  override fun toString(): String =
+    "StateAssertionError on $state" + problems.joinToString(prefix = "\n- ", separator = "\n- ")
+}
 
 public class TraceAssertionError(
   public val trace: List<*>,

--- a/kotlin/test-common/src/commonMain/kotlin/karat/kotlin/test/Validate.kt
+++ b/kotlin/test-common/src/commonMain/kotlin/karat/kotlin/test/Validate.kt
@@ -5,25 +5,25 @@ import karat.concrete.progression.Info
 import karat.concrete.progression.suspend.SuspendStepResultManager
 import kotlin.test.assertTrue
 
-public typealias KotlinTestAtomic<A> = Atomic<A, Unit>
-public typealias KotlinTestFormula<A> = Formula<A, Unit>
+public typealias KotlinTestAtomic<A> = Atomic<A, Any?>
+public typealias KotlinTestFormula<A> = Formula<A, Any?>
 
 public typealias KotlinTestFormulaBuilder<ConcreteState, Action, Response> =
-  ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Unit>
+  ConcreteFormulaBuilder<Info<Action, ConcreteState, Response>, Any?>
 
-public class KotlinTestStepResultManager<A>: SuspendStepResultManager<A, Unit, List<AssertionError>?> {
+public class KotlinTestStepResultManager<A>: SuspendStepResultManager<A, Any?, List<AssertionError>?> {
   override val List<AssertionError>?.isOk: Boolean
     get() = this == null
   override val everythingOk: List<AssertionError>? = null
   override val falseFormula: List<AssertionError> = listOf(FalseError)
   override val unknown: List<AssertionError> = listOf(DoneUnknown)
-  override fun negationWasTrue(formula: Formula<A, Unit>): List<AssertionError> = listOf(NegationWasTrue(formula))
-  override fun shouldHoldEventually(formula: Formula<A, Unit>): List<AssertionError> = listOf(ShouldHoldEventually(formula))
+  override fun negationWasTrue(formula: KotlinTestFormula<A>): List<AssertionError> = listOf(NegationWasTrue(formula))
+  override fun shouldHoldEventually(formula: KotlinTestFormula<A>): List<AssertionError> = listOf(ShouldHoldEventually(formula))
   override fun andResults(results: List<List<AssertionError>?>): List<AssertionError>? =
     if (results.all { it.isOk }) everythingOk else results.flatMap { it.orEmpty() }
   override fun orResults(results: List<List<AssertionError>?>): List<AssertionError>? =
     if (results.any { it.isOk }) everythingOk else results.flatMap { it.orEmpty() }
-  override suspend fun predicate(test: suspend (A) -> Unit, value: A): List<AssertionError>? =
+  override suspend fun predicate(test: suspend (A) -> Any?, value: A): List<AssertionError>? =
     try {
       test(value)
       null
@@ -35,7 +35,7 @@ public class KotlinTestStepResultManager<A>: SuspendStepResultManager<A, Unit, L
 /**
  * Basic formula which checks that an item is produced, and satisfies the [test].
  */
-public fun <A> should(test: suspend (A) -> Unit): KotlinTestAtomic<A> =
+public fun <A> should(test: suspend (A) -> Any?): KotlinTestAtomic<A> =
   Predicate(test)
 
 /**

--- a/kotlin/turbine/build.gradle.kts
+++ b/kotlin/turbine/build.gradle.kts
@@ -14,7 +14,14 @@ kotlin {
         api(libs.turbine)
       }
     }
-    val commonTest by getting
+    val commonTest by getting {
+      dependencies {
+        implementation(libs.turbine)
+        implementation(libs.kotlinx.coroutines)
+        implementation(libs.kotest.frameworkEngine)
+        implementation(libs.kotest.assertionsCore)
+      }
+    }
     val jvmMain by getting
     val jvmTest by getting {
       dependencies {

--- a/kotlin/turbine/src/commonMain/kotlin/karat/turbine/Validate.kt
+++ b/kotlin/turbine/src/commonMain/kotlin/karat/turbine/Validate.kt
@@ -3,18 +3,18 @@ package karat.turbine
 import app.cash.turbine.Event
 import app.cash.turbine.ReceiveTurbine
 import app.cash.turbine.test
-import karat.concrete.Atomic
-import karat.concrete.Formula
 import karat.concrete.progression.suspend.SuspendStepResultManager
 import karat.concrete.progression.suspend.check
 import karat.concrete.progression.suspend.leftToProve
+import karat.kotlin.test.KotlinTestAtomic
+import karat.kotlin.test.KotlinTestFormula
 import karat.kotlin.test.KotlinTestStepResultManager
 import karat.kotlin.test.StateAssertionError
 import kotlinx.coroutines.flow.Flow
 import kotlin.time.Duration
 
-public typealias TurbineAtomic<A> = Atomic<Result<A>, Unit>
-public typealias TurbineFormula<A> = Formula<Result<A>, Unit>
+public typealias TurbineAtomic<A> = KotlinTestAtomic<Result<A>>
+public typealias TurbineFormula<A> = KotlinTestFormula<Result<A>>
 
 /**
  * Checks that the formula holds over the [Flow].
@@ -40,7 +40,7 @@ public suspend fun <A> ReceiveTurbine<A>.formula(block: () -> TurbineFormula<A>)
 private class TurbineStepResultManager<A>(
   val turbine: ReceiveTurbine<A>,
   val manager: KotlinTestStepResultManager<Result<A>>
-): ReceiveTurbine<A> by turbine, SuspendStepResultManager<Result<A>, Unit, List<AssertionError>?> by manager
+): ReceiveTurbine<A> by turbine, SuspendStepResultManager<Result<A>, Any?, List<AssertionError>?> by manager
 
 public suspend fun <A> ReceiveTurbine<A>.formula(
   formula: TurbineFormula<A>

--- a/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
+++ b/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
@@ -54,7 +54,7 @@ class SimpleTest: StringSpec({
   fun Flow<Int>.shakeIt(): Flow<Int> = flatMapConcat {
     flow {
       emit(it)
-      if (it % 5 == 0) emit(it)
+      if (it % 5 == 0) emit(it - 10)
     }
   }
 

--- a/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
+++ b/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
@@ -1,10 +1,12 @@
 package karat.turbine
 
+import app.cash.turbine.test
 import io.kotest.assertions.shouldFail
 import io.kotest.core.spec.style.StringSpec
-import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.ints.shouldBePositive
 import io.kotest.matchers.result.shouldBeSuccess
+import io.kotest.matchers.shouldBe
 import karat.concrete.*
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.*
@@ -12,12 +14,20 @@ import kotlinx.coroutines.flow.*
 @OptIn(FlowPreview::class)
 class SimpleTest: StringSpec({
   val alwaysPositive: TurbineFormula<Int> = always(
-    predicate {it.shouldBeSuccess().shouldBePositive() }
+    predicate { it.shouldBeSuccess().shouldBePositive() }
   )
 
   val atSomePointPositive: TurbineFormula<Int> = eventually(
     predicate { it.shouldBeSuccess().shouldBePositive() }
   )
+
+  "Turbine test" {
+    (1 .. 10).asFlow().test {
+      awaitItem() shouldBe 1
+      awaitItem() shouldBe 2
+      cancelAndIgnoreRemainingEvents()
+    }
+  }
 
   "positive flow" {
     (1 .. 10).asFlow().testFormula { alwaysPositive }
@@ -34,7 +44,7 @@ class SimpleTest: StringSpec({
           predicate { new ->
             val oldValue = old.shouldBeSuccess()
             val newValue = new.shouldBeSuccess()
-            newValue.shouldBeGreaterThan(oldValue)
+            newValue shouldBeGreaterThanOrEqual oldValue
           }
         )
       }

--- a/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
+++ b/kotlin/turbine/src/commonTest/kotlin/karat/turbine/SimpleTest.kt
@@ -1,0 +1,57 @@
+package karat.turbine
+
+import io.kotest.assertions.shouldFail
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.ints.shouldBePositive
+import io.kotest.matchers.result.shouldBeSuccess
+import karat.concrete.*
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.*
+
+@OptIn(FlowPreview::class)
+class SimpleTest: StringSpec({
+  val alwaysPositive: TurbineFormula<Int> = always(
+    predicate {it.shouldBeSuccess().shouldBePositive() }
+  )
+
+  val atSomePointPositive: TurbineFormula<Int> = eventually(
+    predicate { it.shouldBeSuccess().shouldBePositive() }
+  )
+
+  "positive flow" {
+    (1 .. 10).asFlow().testFormula { alwaysPositive }
+    shouldFail {
+      (-1 .. 10).asFlow().testFormula { alwaysPositive }
+    }
+    (-1 .. 10).asFlow().testFormula { atSomePointPositive }
+  }
+
+  val alwaysIncreasing: TurbineFormula<Int> = formula<Result<Int>, _, _> {
+    always(
+      remember { old ->
+        afterwards(
+          predicate { new ->
+            val oldValue = old.shouldBeSuccess()
+            val newValue = new.shouldBeSuccess()
+            newValue.shouldBeGreaterThan(oldValue)
+          }
+        )
+      }
+    )
+  }
+
+  fun Flow<Int>.shakeIt(): Flow<Int> = flatMapConcat {
+    flow {
+      emit(it)
+      if (it % 5 == 0) emit(it)
+    }
+  }
+
+  "increasing flow" {
+    (1 .. 10).asFlow().testFormula { alwaysIncreasing }
+    shouldFail {
+      (1..10).asFlow().shakeIt().testFormula { alwaysIncreasing }
+    }
+  }
+})


### PR DESCRIPTION
This PR adds a few simple tests, in preparation for a coming blog post.

In addition, it generalizes the type of `KotlinTestFormula`. Prior to this PR those formulas had to return `Unit`, but that meant you sometimes had to add an explicit `Unit` at the end of a block. Since `kotlin.test` works by raising exceptions when a problem occurs, the return type doesn't matter. By changing it to `Any?` it becomes much easier to write formulae.