### PR TITLE
Publishing snapshot versions

### DIFF
--- a/.github/workflows/publish_snapshot.yaml
+++ b/.github/workflows/publish_snapshot.yaml
@@ -1,0 +1,56 @@
+name: Publish snapshot artifacts
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx5g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+  SONATYPE_USER: '${{ secrets.SONATYPE_USER }}'
+  SONATYPE_PWD: '${{ secrets.SONATYPE_PWD }}'
+  SIGNING_KEY: '${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}'
+  SIGNING_KEY_ID: '${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}'
+  SIGNING_KEY_PASSPHRASE: '${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}'
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ 'ubuntu-latest' ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-version: 11
+
+      - name: Setup GPG
+        uses: olafurpg/setup-gpg@v3
+
+      - name: Build
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --full-stacktrace build
+          
+      - name: Publish artifacts
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: --full-stacktrace publishToSonatype
+
+      - name: Upload reports
+        uses: actions/upload-artifact@v3
+        with:
+          name: 'reports-${{ matrix.os }}'
+          path: '**/build/reports/**'
+
+      - name: Stop Gradle daemons
+        run: ./gradlew --stop

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,7 @@ allprojects {
   }
 
   group = "com.47deg.karat"
-  version = "0.1-SNAPSHOT"
+  version = "0.1.0-SNAPSHOT"
 
   tasks.withType<Test>().configureEach {
     useJUnitPlatform()

--- a/buildSrc/src/main/kotlin/karat-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/karat-publishing.gradle.kts
@@ -17,11 +17,13 @@ configurePublish()
 val publications: PublicationContainer = extensions.getByName<PublishingExtension>("publishing").publications
 
 signing {
+  val isLocal = gradle.startParameter.taskNames.any { it.contains("publishToMavenLocal", ignoreCase = true) }
+  isRequired = !isLocal
   useGpgCmd()
   useInMemoryPgpKeys(signingKeyId, signingKey, signingPassphrase)
   sign(publications)
 }
 
-tasks.withType<AbstractPublishToMaven>() {
+tasks.withType<AbstractPublishToMaven> {
   dependsOn(tasks.withType<Sign>())
 }


### PR DESCRIPTION
This pull request enables publishing a new snapshot version for every push to the `main` branch. Additionally, it adds a check to avoid signing the artifacts when publishing locally by using `publishToMavenLocal`