### PR TITLE
Using semantic versioning

### DIFF
--- a/.github/workflows/generate_alpha_tag.yaml
+++ b/.github/workflows/generate_alpha_tag.yaml
@@ -1,0 +1,36 @@
+name: Generate alpha tag
+
+on:
+  push:
+    branches: [main]
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx5g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+
+jobs:
+  generate-alpha-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Running test on the JVM
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jvmTest
+
+      - name: Generate Tag
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: createSemverTag "-Psemver.stage=alpha"
+
+      - name: Push Tag
+        run: git push --follow-tags

--- a/.github/workflows/generate_tag.yaml
+++ b/.github/workflows/generate_tag.yaml
@@ -1,0 +1,57 @@
+name: Generate tag
+
+on:
+  workflow_dispatch:
+    branches: [main]
+    inputs:
+      stage:
+        description: 'Stage'
+        required: true
+        default: 'alpha'
+        type: choice
+        options:
+          - 'alpha'
+          - 'beta'
+          - 'rc'
+          - 'final'
+      scope:
+        description: 'Scope'
+        required: true
+        default: 'auto'
+        type: choice
+        options:
+          - 'auto'
+          - 'major'
+          - 'minor'
+          - 'patch'
+
+env:
+  GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx5g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
+
+jobs:
+  generate-alpha-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 11
+
+      - name: Running test on the JVM
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: jvmTest
+
+      - name: Generate Tag
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: createSemverTag "-Psemver.scope=${{ github.event.inputs.scope }}" "-Psemver.stage=${{ github.event.inputs.stage }}"
+
+      - name: Push Tag
+        run: git push --follow-tags

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,8 +1,9 @@
-name: Release and publish artifacts
+name: Publish artifacts for final versions
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
   workflow_dispatch:    
 
 env:

--- a/.github/workflows/publish_non_final_version.yaml
+++ b/.github/workflows/publish_non_final_version.yaml
@@ -1,9 +1,11 @@
-name: Publish snapshot artifacts
+name: Publish artifacts for non-final versions
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 env:
   GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.parallel=false -Dorg.gradle.jvmargs="-Xmx5g -XX:+UseParallelGC -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8"
@@ -44,7 +46,7 @@ jobs:
       - name: Publish artifacts
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: --full-stacktrace publishToSonatype
+          arguments: --full-stacktrace publishToSonatype closeSonatypeStagingRepository
 
       - name: Upload reports
         uses: actions/upload-artifact@v3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@
 plugins {
   alias(libs.plugins.kotlinx.serialization) apply false
   alias(libs.plugins.kotest.multiplatform) apply false
-  alias(libs.plugins.gradle.nexus.publish) apply true
+  alias(libs.plugins.gradle.nexus.publish)
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,7 +13,6 @@ allprojects {
   }
 
   group = "com.47deg.karat"
-  version = "0.1.0-SNAPSHOT"
 
   tasks.withType<Test>().configureEach {
     useJUnitPlatform()

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,5 +8,6 @@ repositories {
 }
 
 dependencies {
+  api(libs.semver.gradlePlugin)
   implementation(libs.kotlin.gradle.plugin)
 }

--- a/buildSrc/src/main/kotlin/karat-publishing.gradle.kts
+++ b/buildSrc/src/main/kotlin/karat-publishing.gradle.kts
@@ -10,6 +10,7 @@ import org.gradle.kotlin.dsl.signing
 plugins {
   signing
   `maven-publish`
+  id("com.javiersc.semver")
 }
 
 configurePublish()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ turbine = "0.12.3"
 scalaMultiversion = "2.0.4"
 scalacheck = "1.17.0"
 scalacheckEffect = "1.0.4"
+semverPlugin = "0.5.0-alpha.2"
 
 [libraries]
 gradleNexus-publishPlugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "gradleNexusPublish" }
@@ -44,6 +45,7 @@ munit-cats-effect = { module = "org.typelevel:munit-cats-effect-3_2.13", version
 scalacheck-core = { module = "org.scalacheck:scalacheck_2.13", version.ref = "scalacheck" }
 scalacheck-effect = { module = "org.typelevel:scalacheck-effect_2.13", version.ref = "scalacheckEffect" }
 scalacheck-effectMunit = { module = "org.typelevel:scalacheck-effect-munit_2.13", version.ref = "scalacheckEffect" }
+semver-gradlePlugin = { module = "com.javiersc.semver:semver-gradle-plugin", version.ref = "semverPlugin" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 
 [plugins]


### PR DESCRIPTION
This pull request proposes using [semantic versioning](https://semver.org/) for the different releases we will publish for the project. The initial proposal is as follows:
- Create a new alpha version tag for every push to the `main` branch. E.g., `0.1.0-alpha.1`, `0.1.0-alpha.2` ... The creation of this new tag will trigger a workflow to publish the artifacts to Maven Central.
- To create a final version, we should create a new tag manually by:
  - Running the `Generate tag` workflow
  - Creating a new release
- The creation of a new version tag will trigger a workflow to publish the artifacts for the final version in Maven Central