### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Java
         uses: actions/setup-java@v3
@@ -36,11 +37,6 @@ jobs:
 
       - name: Setup GPG
         uses: olafurpg/setup-gpg@v3
-
-      - name: Git Status
-        run: |
-          git --version
-          git status
 
       - name: Build
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/publish_non_final_version.yaml
+++ b/.github/workflows/publish_non_final_version.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
       - name: Set up Java
         uses: actions/setup-java@v3

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ _site/
 .jekyll-cache/
 .jekyll-metadata
 
+gnupg-*


### PR DESCRIPTION
The `publish` workflow generates a version number including a `DIRTY` suffix because the repository folder is not clean after installing the GNUPG tool. This pull request fixes this problem by adding the GNU folder in the `.gitignore` file