### PR TITLE
Add token for bot user

### DIFF
--- a/.github/workflows/generate_alpha_tag.yaml
+++ b/.github/workflows/generate_alpha_tag.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.BOT_TOKEN }}
 
       - name: Set up Java
         uses: actions/setup-java@v3


### PR DESCRIPTION
The current workflow that generates a new alpha tag doesn't trigger the workflow to publish the artifacts in Sonatype because a limitation in GitHub Actions prevents it when the GitHub Actions bot acts.

This pull request uses a different token to generate the alpha tag to overcome this limitation.